### PR TITLE
Fix: Resolve build error and reduce video load flickering

### DIFF
--- a/app/hooks/useComments.ts
+++ b/app/hooks/useComments.ts
@@ -149,7 +149,7 @@ function useComments({
 
     const startAutoRefresh = () => {
       if (refreshTimerRef.current) {
-        clearInterval(refetchTimerRef.current);
+        clearInterval(refreshTimerRef.current);
       }
 
       refreshTimerRef.current = setInterval(() => {

--- a/app/video/[videoJsonCid]/page.tsx
+++ b/app/video/[videoJsonCid]/page.tsx
@@ -79,6 +79,7 @@ const VideoPage = () => {
   const [decryptedVideoUrl, setDecryptedVideoUrl] = useState<string | null>(
     null
   )
+  const [isVideoReadyForDisplay, setIsVideoReadyForDisplay] = useState(false) // Added for fade-in effect
   const [isLoading, setIsLoading] = useState(false)
   const [isMetadataLoading, setIsMetadataLoading] = useState(true)
   const [metadataError, setMetadataError] = useState<string | null>(null)
@@ -569,7 +570,10 @@ const VideoPage = () => {
                   width="100%"
                   controls
                   autoPlay
-                  className="w-full h-full object-cover"
+                  onCanPlay={() => setIsVideoReadyForDisplay(true)}
+                  className={`w-full h-full object-cover ${
+                    isVideoReadyForDisplay ? 'opacity-100' : 'opacity-0'
+                  } transition-opacity duration-500 ease-in-out`}
                 />
               ) : decryptedVideoUrl ? (
                 <video


### PR DESCRIPTION
- I corrected a typo in `app/hooks/useComments.ts` (refetchTimerRef -> refreshTimerRef) to fix the TypeScript compilation error.
- I implemented a fade-in effect for public videos on the video detail page (`app/video/[videoJsonCid]/page.tsx`). This is achieved by using an `onCanPlay` event to trigger an opacity change with a CSS transition, aiming to reduce the perceived flickering when a video is loaded for the first time.